### PR TITLE
Add scaffold for AI orchestra prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+.venv/
+.env

--- a/AI_Team_Framework/agents/base_agent.py
+++ b/AI_Team_Framework/agents/base_agent.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+@dataclass
+class AgentTurn:
+    agent_id: str
+    content: str
+    cost_usd: float = 0.0
+    tokens: int = 0
+
+
+class BaseAgent:
+    """Base class encapsulating common agent behaviour.
+
+    The default implementation simply echoes structured placeholders so that
+    the orchestration flow can be exercised without real model calls. Concrete
+    subclasses can override :meth:`compose_turn` to integrate with an API or
+    local model backend.
+    """
+
+    def __init__(
+        self,
+        agent_id: str,
+        config: Dict,
+        prompt_library: Dict[str, str],
+        logger: logging.Logger,
+    ) -> None:
+        self.agent_id = agent_id
+        self.config = config
+        self.prompt_library = prompt_library
+        self.logger = logger
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+    def kickoff_round(self, context: Dict) -> AgentTurn:
+        prompt = self._format_prompt("kickoff_prompt", context)
+        return self.compose_turn(prompt, context)
+
+    def perform_task(self, context: Dict) -> AgentTurn:
+        prompt = self._format_prompt("task_prompt", context)
+        return self.compose_turn(prompt, context)
+
+    def self_evaluate(self, context: Dict) -> AgentTurn:
+        prompt = self._format_prompt("self_eval_prompt", context)
+        return self.compose_turn(prompt, context)
+
+    def review_round(self, context: Dict) -> AgentTurn:
+        prompt = self._format_prompt("review_prompt", context)
+        return self.compose_turn(prompt, context)
+
+    # ------------------------------------------------------------------
+    # Extension hooks
+    # ------------------------------------------------------------------
+    def compose_turn(self, prompt: str, context: Optional[Dict]) -> AgentTurn:
+        """Compose a response for a turn.
+
+        Subclasses should override this method to connect with real LLM APIs.
+        The default implementation simply returns a structured stub message so
+        that the orchestration layer can be exercised in offline mode.
+        """
+
+        self.logger.debug("Stub compose_turn invoked for %s", self.agent_id)
+        headline = self.config.get("role", "team member")
+        response_lines: List[str] = [
+            f"[{self.config.get('display_name', self.agent_id)} | {headline}]",
+            "Prompt summary:",
+            prompt.strip(),
+        ]
+        if context:
+            summary = context.get("conversation_summary") or "(no summary yet)"
+            response_lines.append(f"Latest summary: {summary}")
+        return AgentTurn(agent_id=self.agent_id, content="\n".join(response_lines))
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _format_prompt(self, prompt_key: str, context: Dict) -> str:
+        template = self.prompt_library.get(prompt_key, "")
+        if not template:
+            self.logger.warning("Prompt '%s' missing for agent %s", prompt_key, self.agent_id)
+            return ""
+
+        populated = template.format(
+            agent_name=self.config.get("display_name", self.agent_id),
+            agent_role=self.config.get("role", ""),
+            project_objective=context.get("objective", ""),
+            project_memory=context.get("project_memory", ""),
+        )
+        return populated
+
+
+def load_prompt_library(base_dir: Path, settings: Dict) -> Dict[str, str]:
+    """Load prompt templates declared in the settings file."""
+
+    prompt_map: Dict[str, str] = {}
+    for key in [
+        "kickoff_prompt",
+        "task_prompt",
+        "self_eval_prompt",
+        "review_prompt",
+    ]:
+        path_value = settings.get(key)
+        if not path_value:
+            continue
+        prompt_path = base_dir / path_value
+        try:
+            prompt_map[key] = prompt_path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            prompt_map[key] = ""
+    return prompt_map

--- a/AI_Team_Framework/agents/claude_agent.py
+++ b/AI_Team_Framework/agents/claude_agent.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import logging
+from typing import Dict
+
+from .base_agent import BaseAgent
+
+
+class ClaudeAgent(BaseAgent):
+    """Research synthesis specialist agent."""
+
+    def __init__(self, config: Dict, prompt_library: Dict[str, str], logger: logging.Logger) -> None:
+        super().__init__("claude", config, prompt_library, logger)

--- a/AI_Team_Framework/agents/deepseek_agent.py
+++ b/AI_Team_Framework/agents/deepseek_agent.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import logging
+from typing import Dict
+
+from .base_agent import BaseAgent
+
+
+class DeepSeekAgent(BaseAgent):
+    """Implementation strategy and optimisation agent."""
+
+    def __init__(self, config: Dict, prompt_library: Dict[str, str], logger: logging.Logger) -> None:
+        super().__init__("deepseek", config, prompt_library, logger)

--- a/AI_Team_Framework/agents/gemini_agent.py
+++ b/AI_Team_Framework/agents/gemini_agent.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import logging
+from typing import Dict
+
+from .base_agent import BaseAgent
+
+
+class GeminiAgent(BaseAgent):
+    """Default implementation for the Gemini head orchestrator."""
+
+    def __init__(self, config: Dict, prompt_library: Dict[str, str], logger: logging.Logger) -> None:
+        super().__init__("gemini", config, prompt_library, logger)

--- a/AI_Team_Framework/agents/gpt_agent.py
+++ b/AI_Team_Framework/agents/gpt_agent.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import logging
+from typing import Dict
+
+from .base_agent import BaseAgent
+
+
+class GPTAgent(BaseAgent):
+    """Technical planning and specification agent."""
+
+    def __init__(self, config: Dict, prompt_library: Dict[str, str], logger: logging.Logger) -> None:
+        super().__init__("gpt", config, prompt_library, logger)

--- a/AI_Team_Framework/config/agents.json
+++ b/AI_Team_Framework/config/agents.json
@@ -1,0 +1,53 @@
+{
+  "agents": [
+    {
+      "id": "gemini",
+      "display_name": "Gemini",
+      "provider": "google",
+      "model": "gemini-1.5-pro",
+      "role": "Head orchestrator and systems manager",
+      "privileges": {
+        "filesystem": true,
+        "applications": ["notepad"],
+        "api_access": true
+      }
+    },
+    {
+      "id": "claude",
+      "display_name": "Claude",
+      "provider": "anthropic",
+      "model": "claude-3-opus",
+      "role": "Research synthesis and critique",
+      "privileges": {
+        "filesystem": false,
+        "applications": [],
+        "api_access": true
+      }
+    },
+    {
+      "id": "gpt",
+      "display_name": "GPT-4",
+      "provider": "openai",
+      "model": "gpt-4.1",
+      "role": "Technical planning and specification",
+      "privileges": {
+        "filesystem": false,
+        "applications": [],
+        "api_access": true
+      }
+    },
+    {
+      "id": "deepseek",
+      "display_name": "DeepSeek",
+      "provider": "deepseek",
+      "model": "deepseek-chat",
+      "role": "Implementation strategist and optimizer",
+      "privileges": {
+        "filesystem": false,
+        "applications": [],
+        "api_access": true
+      }
+    }
+  ],
+  "default_order": ["gemini", "claude", "gpt", "deepseek"]
+}

--- a/AI_Team_Framework/config/limits.json
+++ b/AI_Team_Framework/config/limits.json
@@ -1,0 +1,7 @@
+{
+  "max_tokens_per_round": 12000,
+  "max_cost_usd": 2.50,
+  "max_elapsed_minutes": 15,
+  "auto_pause": true,
+  "grace_period_seconds": 5
+}

--- a/AI_Team_Framework/config/settings.json
+++ b/AI_Team_Framework/config/settings.json
@@ -1,0 +1,13 @@
+{
+  "rounds": 1,
+  "talk_back_cycles": 2,
+  "log_level": "INFO",
+  "kickoff_prompt": "prompts/round_kickoff_prompt.txt",
+  "task_prompt": "prompts/task_prompt.txt",
+  "self_eval_prompt": "prompts/self_eval_prompt.txt",
+  "review_prompt": "prompts/review_prompt.txt",
+  "default_turn_timeout_seconds": 120,
+  "conversation_log_dir": "memory/logs",
+  "project_memory_file": "memory/project_memory.md",
+  "output_file": "output/saved_outputs.md"
+}

--- a/AI_Team_Framework/memory/logs/claude_log.md
+++ b/AI_Team_Framework/memory/logs/claude_log.md
@@ -1,0 +1,3 @@
+# Claude Activity Log
+
+Entries are appended automatically each time the Claude agent takes a turn.

--- a/AI_Team_Framework/memory/logs/deepseek_log.md
+++ b/AI_Team_Framework/memory/logs/deepseek_log.md
@@ -1,0 +1,3 @@
+# DeepSeek Activity Log
+
+Entries are appended automatically each time the DeepSeek agent takes a turn.

--- a/AI_Team_Framework/memory/logs/gemini_log.md
+++ b/AI_Team_Framework/memory/logs/gemini_log.md
@@ -1,0 +1,3 @@
+# Gemini Activity Log
+
+Entries are appended automatically each time the Gemini agent takes a turn.

--- a/AI_Team_Framework/memory/logs/gpt_log.md
+++ b/AI_Team_Framework/memory/logs/gpt_log.md
@@ -1,0 +1,3 @@
+# GPT Activity Log
+
+Entries are appended automatically each time the GPT agent takes a turn.

--- a/AI_Team_Framework/memory/project_memory.md
+++ b/AI_Team_Framework/memory/project_memory.md
@@ -1,0 +1,3 @@
+# Project Memory
+
+Use this space to capture persistent knowledge, decisions, and resources relevant to the current initiative.

--- a/AI_Team_Framework/orchestrator/__init__.py
+++ b/AI_Team_Framework/orchestrator/__init__.py
@@ -1,0 +1,1 @@
+"""Orchestrator package exposing coordination utilities."""

--- a/AI_Team_Framework/orchestrator/coordinator.py
+++ b/AI_Team_Framework/orchestrator/coordinator.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+from agents.base_agent import AgentTurn
+from .reward_engine import RewardEngine
+
+
+class BudgetTracker:
+    """Tracks usage against configured limits and raises on overflow."""
+
+    def __init__(self, limits: Dict) -> None:
+        self.limits = limits
+        self.total_tokens = 0
+        self.total_cost = 0.0
+        self.start_time = time.monotonic()
+
+    def register_turn(self, turn: AgentTurn) -> None:
+        self.total_tokens += turn.tokens
+        self.total_cost += turn.cost_usd
+
+    def check_limits(self) -> Optional[str]:
+        if self.total_tokens > self.limits.get("max_tokens_per_round", float("inf")):
+            return "Token budget exceeded"
+        if self.total_cost > self.limits.get("max_cost_usd", float("inf")):
+            return "Cost budget exceeded"
+        elapsed_minutes = (time.monotonic() - self.start_time) / 60
+        if elapsed_minutes > self.limits.get("max_elapsed_minutes", float("inf")):
+            return "Time budget exceeded"
+        return None
+
+
+class Coordinator:
+    """Coordinates round-based collaboration between agents."""
+
+    def __init__(
+        self,
+        base_dir: Path,
+        agents: Dict[str, object],
+        config: Dict,
+        settings: Dict,
+        limits: Dict,
+        reward_engine: RewardEngine,
+        logger: logging.Logger,
+    ) -> None:
+        self.base_dir = base_dir
+        self.agents = agents
+        self.config = config
+        self.settings = settings
+        self.limits = limits
+        self.reward_engine = reward_engine
+        self.logger = logger
+        self.order = config.get("default_order", list(agents.keys()))
+        self.log_dir = base_dir / settings.get("conversation_log_dir", "memory/logs")
+        self.project_memory_path = base_dir / settings.get("project_memory_file", "memory/project_memory.md")
+        self.output_path = base_dir / settings.get("output_file", "output/saved_outputs.md")
+
+    # ------------------------------------------------------------------
+    def run(self, rounds: int) -> None:
+        for round_index in range(1, rounds + 1):
+            self.logger.info("Starting round %s", round_index)
+            budget = BudgetTracker(self.limits)
+            round_context = self._initial_round_context(round_index)
+            self._kickoff_round(round_context, budget)
+            self._run_task_phase(round_context, budget)
+            self._finalise_round(round_context, budget)
+            self.logger.info("Completed round %s", round_index)
+
+    # ------------------------------------------------------------------
+    def _kickoff_round(self, context: Dict, budget: BudgetTracker) -> None:
+        head_id = self.order[0]
+        head_agent = self.agents[head_id]
+        turn = head_agent.kickoff_round(context)
+        self._persist_turn(turn, context)
+        budget.register_turn(turn)
+        self._check_budget(budget)
+        context["conversation_summary"] = turn.content
+
+    def _run_task_phase(self, context: Dict, budget: BudgetTracker) -> None:
+        talk_back_cycles = self.settings.get("talk_back_cycles", 0)
+        for cycle in range(talk_back_cycles):
+            self.logger.debug("Talk-back cycle %s", cycle + 1)
+            for agent_id in self._iter_task_agents():
+                agent = self.agents[agent_id]
+                turn = agent.perform_task(context)
+                self._persist_turn(turn, context)
+                budget.register_turn(turn)
+                self._check_budget(budget)
+                context["conversation_summary"] = self._update_summary(context, turn)
+                self.reward_engine.record_contribution(agent_id, turn.content)
+
+    def _finalise_round(self, context: Dict, budget: BudgetTracker) -> None:
+        reviewer_id = self.order[0]
+        reviewer = self.agents[reviewer_id]
+        review_turn = reviewer.review_round(context)
+        self._persist_turn(review_turn, context)
+        budget.register_turn(review_turn)
+        self._check_budget(budget)
+        context["conversation_summary"] = self._update_summary(context, review_turn)
+        self._append_round_summary(context)
+
+    # ------------------------------------------------------------------
+    def _persist_turn(self, turn: AgentTurn, context: Dict) -> None:
+        log_path = self.log_dir / f"{turn.agent_id}_log.md"
+        log_entry = self._format_log_entry(turn, context)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a", encoding="utf-8") as handle:
+            handle.write(log_entry + "\n\n")
+        self.logger.debug("Logged turn for %s", turn.agent_id)
+
+    def _format_log_entry(self, turn: AgentTurn, context: Dict) -> str:
+        entry = {
+            "agent": turn.agent_id,
+            "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
+            "tokens": turn.tokens,
+            "cost": turn.cost_usd,
+            "summary": context.get("conversation_summary", ""),
+            "content": turn.content,
+        }
+        return json.dumps(entry, ensure_ascii=False, indent=2)
+
+    def _check_budget(self, tracker: BudgetTracker) -> None:
+        violation = tracker.check_limits()
+        if violation:
+            self.logger.error("%s -- initiating auto pause", violation)
+            if self.limits.get("auto_pause", True):
+                raise RuntimeError(violation)
+
+    def _update_summary(self, context: Dict, turn: AgentTurn) -> str:
+        summary = context.get("conversation_summary", "")
+        updated = f"{summary}\n{turn.agent_id}: {turn.content.strip()}".strip()
+        return updated
+
+    def _append_round_summary(self, context: Dict) -> None:
+        self.output_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.output_path.open("a", encoding="utf-8") as handle:
+            handle.write(f"\n## Round Summary\n\n{context.get('conversation_summary', '').strip()}\n")
+
+    def _initial_round_context(self, round_index: int) -> Dict:
+        project_memory = ""
+        if self.project_memory_path.exists():
+            project_memory = self.project_memory_path.read_text(encoding="utf-8")
+        return {
+            "round": round_index,
+            "objective": self.settings.get("round_objective", ""),
+            "project_memory": project_memory,
+            "conversation_summary": "",
+        }
+
+    def _iter_task_agents(self) -> Iterable[str]:
+        if len(self.order) <= 1:
+            return []
+        return self.order

--- a/AI_Team_Framework/orchestrator/reward_engine.py
+++ b/AI_Team_Framework/orchestrator/reward_engine.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Dict
+
+
+class RewardEngine:
+    """Simple reward tracker persisting agent performance metrics."""
+
+    def __init__(self, base_dir: Path, logger: logging.Logger) -> None:
+        self.base_dir = base_dir
+        self.logger = logger
+        self.rewards_path = base_dir / "rewards" / "agent_scores.json"
+        self.rewards_path.parent.mkdir(parents=True, exist_ok=True)
+        self._scores = self._load_scores()
+
+    # ------------------------------------------------------------------
+    def record_contribution(self, agent_id: str, content: str) -> None:
+        score_delta = self._score_from_content(content)
+        entry = self._scores.setdefault(agent_id, {"score": 0, "last_updated": None})
+        entry["score"] = entry.get("score", 0) + score_delta
+        entry["last_updated"] = datetime.utcnow().isoformat()
+        self._persist()
+        self.logger.debug("Recorded contribution for %s (Δ=%s)", agent_id, score_delta)
+
+    def get_scores(self) -> Dict[str, Dict]:
+        return self._scores
+
+    # ------------------------------------------------------------------
+    def _score_from_content(self, content: str) -> int:
+        """Naive heuristic: reward longer, structured contributions."""
+
+        if not content:
+            return 0
+        lines = [line for line in content.splitlines() if line.strip()]
+        return max(1, min(len(lines), 5))
+
+    def _load_scores(self) -> Dict:
+        if not self.rewards_path.exists():
+            return {}
+        try:
+            return json.loads(self.rewards_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            self.logger.warning("Failed to parse rewards file; resetting.")
+            return {}
+
+    def _persist(self) -> None:
+        with self.rewards_path.open("w", encoding="utf-8") as handle:
+            json.dump(self._scores, handle, indent=2)

--- a/AI_Team_Framework/output/saved_outputs.md
+++ b/AI_Team_Framework/output/saved_outputs.md
@@ -1,0 +1,3 @@
+# Saved Outputs
+
+This file captures finalized deliverables from completed rounds. The coordinator appends structured summaries here.

--- a/AI_Team_Framework/prompts/review_prompt.txt
+++ b/AI_Team_Framework/prompts/review_prompt.txt
@@ -1,0 +1,1 @@
+As the reviewing agent, summarize the round's discussion, highlight key insights, and note any follow-up tasks.

--- a/AI_Team_Framework/prompts/round_kickoff_prompt.txt
+++ b/AI_Team_Framework/prompts/round_kickoff_prompt.txt
@@ -1,0 +1,4 @@
+Head Agent Instructions:
+1. Greet the team and state the current objective.
+2. Summarize relevant context from project_memory.md.
+3. Assign responsibilities for this round and confirm the order of turns.

--- a/AI_Team_Framework/prompts/self_eval_prompt.txt
+++ b/AI_Team_Framework/prompts/self_eval_prompt.txt
@@ -1,0 +1,2 @@
+Reflect on your last response in light of the team objectives and constraints.
+Identify one strength and one improvement area for your contribution.

--- a/AI_Team_Framework/prompts/task_prompt.txt
+++ b/AI_Team_Framework/prompts/task_prompt.txt
@@ -1,0 +1,3 @@
+You are {agent_name}, a cooperative research agent focusing on {agent_role}.
+Review the shared project memory and the latest discussion summary.
+Provide your proposed contribution for the current task, citing any files you reference.

--- a/AI_Team_Framework/rewards/agent_scores.json
+++ b/AI_Team_Framework/rewards/agent_scores.json
@@ -1,0 +1,18 @@
+{
+  "gemini": {
+    "score": 0,
+    "last_updated": null
+  },
+  "claude": {
+    "score": 0,
+    "last_updated": null
+  },
+  "gpt": {
+    "score": 0,
+    "last_updated": null
+  },
+  "deepseek": {
+    "score": 0,
+    "last_updated": null
+  }
+}

--- a/AI_Team_Framework/run.py
+++ b/AI_Team_Framework/run.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Dict
+
+from agents.base_agent import load_prompt_library
+from agents.claude_agent import ClaudeAgent
+from agents.deepseek_agent import DeepSeekAgent
+from agents.gemini_agent import GeminiAgent
+from agents.gpt_agent import GPTAgent
+from orchestrator.coordinator import Coordinator
+from orchestrator.reward_engine import RewardEngine
+
+
+AGENT_FACTORY = {
+    "gemini": GeminiAgent,
+    "claude": ClaudeAgent,
+    "gpt": GPTAgent,
+    "deepseek": DeepSeekAgent,
+}
+
+
+def configure_logging(level: str) -> logging.Logger:
+    numeric_level = getattr(logging, level.upper(), logging.INFO)
+    logging.basicConfig(
+        level=numeric_level,
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    )
+    return logging.getLogger("ai_orchestra")
+
+
+def load_json(path: Path) -> Dict:
+    if not path.exists():
+        raise FileNotFoundError(f"Missing configuration file: {path}")
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def initialise_agents(agent_config: Dict, prompt_library: Dict[str, str], logger: logging.Logger):
+    agents = {}
+    for spec in agent_config.get("agents", []):
+        agent_id = spec["id"]
+        factory = AGENT_FACTORY.get(agent_id)
+        if not factory:
+            logger.warning("No factory registered for agent '%s'", agent_id)
+            continue
+        agent_logger = logging.getLogger(f"ai_orchestra.agent.{agent_id}")
+        agents[agent_id] = factory(spec, prompt_library, agent_logger)
+    return agents
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the AI Orchestra prototype")
+    parser.add_argument("--base-dir", default=Path(__file__).resolve().parent, type=Path)
+    parser.add_argument("--rounds", type=int, default=None, help="Override number of rounds")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    base_dir: Path = args.base_dir
+
+    settings = load_json(base_dir / "config" / "settings.json")
+    limits = load_json(base_dir / "config" / "limits.json")
+    agent_config = load_json(base_dir / "config" / "agents.json")
+
+    logger = configure_logging(settings.get("log_level", "INFO"))
+    logger.info("Initialising AI Orchestra from %s", base_dir)
+
+    prompt_library = load_prompt_library(base_dir, settings)
+    reward_engine = RewardEngine(base_dir, logger.getChild("rewards"))
+
+    agents = initialise_agents(agent_config, prompt_library, logger)
+    if not agents:
+        raise RuntimeError("No agents could be initialised. Check config/agents.json")
+
+    rounds = args.rounds or settings.get("rounds", 1)
+    coordinator = Coordinator(
+        base_dir=base_dir,
+        agents=agents,
+        config=agent_config,
+        settings=settings,
+        limits=limits,
+        reward_engine=reward_engine,
+        logger=logger.getChild("coordinator"),
+    )
+
+    try:
+        coordinator.run(rounds=rounds)
+    except RuntimeError as exc:
+        logger.error("Run halted: %s", exc)
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -1,1 +1,100 @@
-# AI-orchestrator
+# Logos-Coherent Multi-Agent AI Orchestra
+
+This repository contains a runnable prototype for David Lowe's **Project Symphony**. The goal is to provide a coherent, turn-based coordination layer that enables several foundation models (Gemini, Claude, GPT, DeepSeek) to collaborate politely while respecting budget, time, and governance constraints.
+
+The prototype currently ships with the API-based approach described by the Architect. It emphasises clear structure, configuration-driven behaviour, and safe extension points for future API calls or browser-automation integrations.
+
+## Folder Structure
+
+```
+AI_Team_Framework/
+├── run.py
+├── agents/
+│   ├── base_agent.py
+│   ├── claude_agent.py
+│   ├── deepseek_agent.py
+│   ├── gemini_agent.py
+│   └── gpt_agent.py
+├── orchestrator/
+│   ├── __init__.py
+│   ├── coordinator.py
+│   └── reward_engine.py
+├── memory/
+│   ├── project_memory.md
+│   └── logs/
+│       ├── claude_log.md
+│       ├── deepseek_log.md
+│       ├── gemini_log.md
+│       └── gpt_log.md
+├── prompts/
+│   ├── round_kickoff_prompt.txt
+│   ├── review_prompt.txt
+│   ├── self_eval_prompt.txt
+│   └── task_prompt.txt
+├── config/
+│   ├── agents.json
+│   ├── limits.json
+│   └── settings.json
+├── rewards/
+│   └── agent_scores.json
+└── output/
+    └── saved_outputs.md
+```
+
+Each directory is intentionally human-readable and editable, making it simple to adapt the orchestration behaviour without modifying Python code.
+
+## Quick Start
+
+1. **Install dependencies** (Python 3.9+ is required). The current prototype only uses the standard library, but virtualenv management is recommended for future API client installations.
+
+   ```bash
+   cd AI_Team_Framework
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt  # optional; create when adding dependencies
+   ```
+
+2. **Provide API keys** (future use). Create a `.env` file in `AI_Team_Framework/` with entries such as `OPENAI_API_KEY=...`, `ANTHROPIC_API_KEY=...`, etc. The stub agent implementations do not yet call external services, but the structure is ready for those integrations.
+
+3. **Run a coordination round**:
+
+   ```bash
+   python run.py
+   ```
+
+   Use `--rounds N` to run multiple rounds or `--base-dir` to point at a different project directory.
+
+4. **Inspect the results**:
+   * `memory/logs/<agent>_log.md` – JSON-formatted entries for each turn.
+   * `rewards/agent_scores.json` – evolving performance scores.
+   * `output/saved_outputs.md` – round summaries suitable for canonisation.
+
+## Configuration
+
+- `config/agents.json` – Declares available agents, their model providers, and privilege levels. Add additional metadata (e.g., budgeting rules, orchestration weights) as needed.
+- `config/settings.json` – Controls the rhythm of the conversation (round count, talk-back cycles, prompt paths, logging level).
+- `config/limits.json` – Defines strict caps on tokens, cost, and elapsed time. When a limit is exceeded the run halts automatically.
+
+All configuration files are editable while the system is offline. The coordinator re-reads them on startup.
+
+## Extending the Prototype
+
+- **API Integration** – Override `BaseAgent.compose_turn` within the concrete agent classes to call real APIs. The `AgentTurn` dataclass already carries token and cost metadata for budget enforcement.
+- **Browser Automation Mode** – Implement an alternative agent subclass that drives browsers via Playwright/Selenium. The current coordinator can host both API and browser-driven agents simultaneously.
+- **Private Side-Chats** – Extend `Coordinator` with a method that spins up 1-on-1 contexts, reusing the existing logging and budgeting tools.
+- **Reward Policies** – Adjust `RewardEngine._score_from_content` to incorporate rubric-based scoring, human feedback, or automated evaluation metrics.
+
+## Safety & Governance
+
+- **Budget Guardrails** – `BudgetTracker` halts execution when limits are breached (tokens, cost, or wall-clock time).
+- **Logging & Transparency** – Every agent contribution is persisted alongside a timestamp and the latest conversation summary for post-run auditing.
+- **Role Rotation** – Update `default_order` in `config/agents.json` to rotate the Head AI and control speaking order. Future enhancements can derive the order dynamically from reward scores.
+
+## Next Steps
+
+- Connect each agent to the respective API clients and populate `.env` handling.
+- Implement private manager-agent conversations and approval workflows for privileged actions.
+- Build the browser automation alternative for environments where API usage is cost-prohibitive.
+- Replace the stub scoring heuristic with a rubric informed by canon integration decisions.
+
+The current code base is intentionally lightweight yet opinionated, providing the scaffolding required to conduct structured multi-agent collaboration in alignment with the Architect's ethos.


### PR DESCRIPTION
## Summary
- add the AI_Team_Framework package with base agents, orchestration loop, and reward tracking
- seed configuration, prompts, memory, and output templates for structured collaboration
- expand the README with setup instructions and add a basic .gitignore

## Testing
- python AI_Team_Framework/run.py

------
https://chatgpt.com/codex/tasks/task_e_68d7bb3b77c48331875c96d4c07f2e36